### PR TITLE
unversioned_cask_checker.rb - fix signature of KeyboardLayout

### DIFF
--- a/Library/Homebrew/unversioned_cask_checker.rb
+++ b/Library/Homebrew/unversioned_cask_checker.rb
@@ -29,7 +29,7 @@ module Homebrew
       @apps ||= @cask.artifacts.select { |a| a.is_a?(Cask::Artifact::App) }
     end
 
-    sig { returns(T::Array[Cask::Artifact::Qlplugin]) }
+    sig { returns(T::Array[Cask::Artifact::KeyboardLayout]) }
     def keyboard_layouts
       @keyboard_layouts ||= @cask.artifacts.select { |a| a.is_a?(Cask::Artifact::KeyboardLayout) }
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The signature is wrong for `Cask::Artifact::KeyboardLayout`:

Reference:
- in PR #15061 `Add keyboard_layout stanza.` this was introduced as a wrong signature

